### PR TITLE
Fix IE 8 complains for instanceof on non-function

### DIFF
--- a/jquery.hc-sticky.js
+++ b/jquery.hc-sticky.js
@@ -342,7 +342,7 @@
 				var $container;
 		                var stickto_is_document = false;
 		                if (options.stickTo) {
-		                    if (typeof options.stickTo == 'string') {
+		                    if (typeof options.stickTo == 'string' && options.stickTo !== 'document') {
 		                        $container = $(options.stickTo);
 		                    } else if (options.stickTo == 'document' || options.stickTo instanceof HTMLDocument) {
 		                        $container = $document;


### PR DESCRIPTION
IE 8 expects the left side of an instanceof expression to be a function. Since stickTo
could be a string. Protect against that case and also create a flag for later checks.
