### PR TITLE
Add check to onscroll functionality to ensure element is visible

### DIFF
--- a/jquery.hc-sticky.js
+++ b/jquery.hc-sticky.js
@@ -367,7 +367,7 @@
 				var onScroll = function(init) {
 
 					// check if we need to run sticky
-					if (!options.on || $this.outerHeight(true) >= $container.height()) return;
+					if (!options.on || !$this.is(':visible') || $this.outerHeight(true) >= $container.height()) return;
 
 					var top_spacing = (options.innerSticker) ? $(options.innerSticker).position().top : ((options.innerTop) ? options.innerTop : 0),
 						wrapper_inner_top = $wrapper.offset().top,


### PR DESCRIPTION
The scroll event is triggered for all instances of hcSticky on the page, even if they're not visible. This was causing a bug where, after scrolling, the hcSticky element which was hidden would snap to the top of the page with fixed positioning. The bug is demonstrated in the following gif:

![hc-sticky-bug](https://cloud.githubusercontent.com/assets/807425/3950465/911b1d32-26c5-11e4-8165-f049bcde5f27.gif)

I have added a check to the onscroll functionality to ensure that the element is visible before continuing. This resolves the bug demonstrated above.
