### PR TITLE
Make values offResolutions match values media queries

### DIFF
--- a/jquery.hc-sticky.js
+++ b/jquery.hc-sticky.js
@@ -584,13 +584,13 @@
 						$.each(options.offResolutions, function(i, rez){
 							if (rez < 0) {
 								// below
-								if ($window.width() < rez * -1) {
+								if (window.innerWidth < rez * -1) {
 									isOn = false;
 									$this.hcSticky('off');
 								}
 							} else {
 								// abowe
-								if ($window.width() > rez) {
+								if (window.innerWidth > rez) {
 									isOn = false;
 									$this.hcSticky('off');
 								}


### PR DESCRIPTION
The `offResolutions` mechanism used `$(window).width()` for matching, but this excludes the width of potential scrollbars, and therefor often does not correspond to width-based media queries. Using `window.innerWidth` for matching instead fixes this. (Sadly, the jQuery `$(window).innerWidth` is utterly useless in this case.)
