### PR TITLE
fix for flexbox parent nodes where the container is the same height a…

### DIFF
--- a/src/hc-sticky.js
+++ b/src/hc-sticky.js
@@ -567,7 +567,7 @@
       calcSticky();
 
       // check if sticky is bigger than reffering container
-      if (sticky_height >= container_height) {
+      if (sticky_height > container_height) {
         disableSticky();
         return;
       }


### PR DESCRIPTION
Fixes case where a parent nodes is `display: flex` as a child node would never stick as it is of equal height.